### PR TITLE
Fixed namespace for ImageDeprecated to comply with psr-4 autoloading

### DIFF
--- a/src/Jarboe/Table/Fields/Deprecated/ImageDeprecated.php
+++ b/src/Jarboe/Table/Fields/Deprecated/ImageDeprecated.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Yaro\Jarboe\Table\Fields;
+namespace Yaro\Jarboe\Table\Fields\Deprecated;
 
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;


### PR DESCRIPTION
Deprecation Notice: Class Yaro\Jarboe\Table\Fields\ImageDeprecated located in ./vendor/yaro/jarboe/src/Jarboe/Table/Fields/Deprecated/ImageDeprecated.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201