### PR TITLE
Implement a separate error count for tabs on each field

### DIFF
--- a/src/Jarboe/Table/CrudTraits/TabsTrait.php
+++ b/src/Jarboe/Table/CrudTraits/TabsTrait.php
@@ -13,7 +13,7 @@ trait TabsTrait
         $fields = $tabs[$tabTitle];
 
         foreach ($fields as $field) {
-            $count += count($errors->get($field->name()));
+            $count += $field->getErrorsCount($errors);
         }
 
         return $count;

--- a/src/Jarboe/Table/Fields/AbstractField.php
+++ b/src/Jarboe/Table/Fields/AbstractField.php
@@ -152,6 +152,11 @@ abstract class AbstractField implements FieldPropsInterface
         return false;
     }
 
+    public function getErrorsCount($errors): int
+    {
+        return count($errors->get($this->name()));
+    }
+
     public function getHistoryView($value)
     {
         return view('jarboe::crud.fields.abstract.history', [

--- a/src/Jarboe/Table/Fields/Text.php
+++ b/src/Jarboe/Table/Fields/Text.php
@@ -3,6 +3,7 @@
 namespace Yaro\Jarboe\Table\Fields;
 
 use Illuminate\Http\Request;
+use Illuminate\Support\ViewErrorBag;
 use Yaro\Jarboe\Table\Fields\Traits\BelongsToArray;
 use Yaro\Jarboe\Table\Fields\Traits\Clipboard;
 use Yaro\Jarboe\Table\Fields\Traits\Inline;
@@ -67,5 +68,14 @@ class Text extends AbstractField
         return view('jarboe::crud.fields.text.'. $template, [
             'field' => $this,
         ]);
+    }
+
+    public function getErrorsCount($errors): int
+    {
+        if ($this->isTranslatable() === true) {
+            return count($errors->get(sprintf('%s.*', $this->name())));
+        }
+
+        return count($errors->get($this->name()));
     }
 }

--- a/src/Jarboe/Table/Fields/Text.php
+++ b/src/Jarboe/Table/Fields/Text.php
@@ -3,7 +3,6 @@
 namespace Yaro\Jarboe\Table\Fields;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\ViewErrorBag;
 use Yaro\Jarboe\Table\Fields\Traits\BelongsToArray;
 use Yaro\Jarboe\Table\Fields\Traits\Clipboard;
 use Yaro\Jarboe\Table\Fields\Traits\Inline;

--- a/src/Jarboe/Table/Fields/Traits/Tab.php
+++ b/src/Jarboe/Table/Fields/Traits/Tab.php
@@ -17,4 +17,6 @@ trait Tab
     {
         return $this->tab;
     }
+
+    public abstract function getErrorsCount($errors): int;
 }

--- a/src/Jarboe/Table/Fields/Traits/Tab.php
+++ b/src/Jarboe/Table/Fields/Traits/Tab.php
@@ -18,5 +18,5 @@ trait Tab
         return $this->tab;
     }
 
-    public abstract function getErrorsCount($errors): int;
+    abstract public function getErrorsCount($errors): int;
 }


### PR DESCRIPTION
At the moment, the library has a problem with subtracting the number of errors in the tab, the code did not read the errors that are tied to the nested name, ie such as translatable and possibly some more, so I think it would be correct to count the number of errors for the tab in the field. Of course I will be happy if I am told what I did wrong.

In my pull request, I implemented the `getErrorsCount` method only in the `Yaro\Jarboe\Table\Fields\Text` field and how I did not want to waste time if the application is rejected, but simply suggest a solution)

Find bug in:
```
trait TabsTrait
{
    public function getTabErrorsCount($tabTitle, $errors)
    {
        $count = 0;
        $tabs = $this->getTabs();
        $fields = $tabs[$tabTitle];

        foreach ($fields as $field) {
            $count += count($errors->get($field->name())); //here because https://i.imgur.com/6ruAICX.png
        }

        return $count;
    }
    ....
}
```
Before change https://i.imgur.com/G1yrSib.png , after https://i.imgur.com/tqHEBs3.png
